### PR TITLE
Update localytics

### DIFF
--- a/ScalaDays/Podfile
+++ b/ScalaDays/Podfile
@@ -9,30 +9,30 @@ use_frameworks!
 abstract_target 'ScalaDaysPods' do
   # Alamofire
   pod 'Alamofire', :git => 'https://github.com/Alamofire/Alamofire.git', :tag => '4.5.1'
-  
+
   # Twitter
   pod 'TwitterKit', '3.3.0'
-  
+
   target 'ScalaDays' do
     # Google Analytics
     pod 'GoogleAnalytics'
-    
+
     # Crashlytics
     pod 'Crashlytics', '3.10.1'
-          
+
     # UI
     pod 'SDWebImage', '~> 3.5'
     pod 'SVProgressHUD', '~> 1.0'
     pod 'UIView+AutoLayout', '~> 1.3'
-    
+
     # QR code library
     pod 'ZBarSDK', '~> 1.3.1'
-    
+
     # Miscellaneous Utils
     pod 'NSDate+TimeAgo', '~> 1.0.2'
-    
+
     # Push notifications
-    pod 'Localytics', '~> 5.1.0'
+    pod 'Localytics', '~> 5.5'
   end
 
   target 'ScalaDaysTests' do

--- a/ScalaDays/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays/ScalaDays.xcodeproj/project.pbxproj
@@ -620,7 +620,6 @@
 					};
 					A1D795DB1A68267F009CCEB3 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 985FQDQUFA;
 						LastSwiftMigration = 0930;
 						TestTargetID = A1D795C61A68267F009CCEB3;
 					};
@@ -631,6 +630,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -695,7 +695,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle",
 			);
@@ -706,7 +706,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		335B04AA5CFE12E35FEF219F /* [CP] Check Pods Manifest.lock */ = {
@@ -733,9 +733,9 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${PODS_ROOT}/Localytics/Localytics-iOS-5.1.0/Localytics.framework",
+				"${PODS_ROOT}/Localytics/Localytics-iOS-5.5.0/Localytics.framework",
 				"${BUILT_PRODUCTS_DIR}/NSDate+TimeAgo/NSDate_TimeAgo.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
@@ -758,7 +758,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDays/Pods-ScalaDaysPods-ScalaDays-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		5917D74B01E4D29CAD47F4D5 /* [CP] Copy Pods Resources */ = {
@@ -767,7 +767,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterKitResources.bundle",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle",
 			);
@@ -778,7 +778,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A1C8B87B1A8E7597008599FF /* ShellScript */ = {
@@ -800,7 +800,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${PODS_ROOT}/TwitterCore/iOS/TwitterCore.framework",
 				"${PODS_ROOT}/TwitterKit/iOS/TwitterKit.framework",
@@ -813,7 +813,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScalaDaysPods-ScalaDaysTests/Pods-ScalaDaysPods-ScalaDaysTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B581528B7986FBD4884AF5 /* [CP] Check Pods Manifest.lock */ = {
@@ -1129,6 +1129,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -1156,6 +1157,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/ScalaDays/ScalaDays.xcodeproj/project.pbxproj
+++ b/ScalaDays/ScalaDays.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 					A1D795C61A68267F009CCEB3 = {
 						CreatedOnToolsVersion = 6.1.1;
 						LastSwiftMigration = 0930;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -1061,9 +1061,9 @@
 				CODE_SIGN_ENTITLEMENTS = ScalaDays/ScalaDays.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = P548S5LU96;
-				ENABLE_BITCODE = NO;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ScalaDays",
@@ -1097,9 +1097,9 @@
 				CODE_SIGN_ENTITLEMENTS = ScalaDays/ScalaDays.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = P548S5LU96;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/ScalaDays",
@@ -1115,7 +1115,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg.scaladays;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Scala Days Production Provisioning Profile";
 				SWIFT_OBJC_BRIDGING_HEADER = "ScalaDays/Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;

--- a/ScalaDays/ScalaDays/AppDelegate.swift
+++ b/ScalaDays/ScalaDays/AppDelegate.swift
@@ -15,11 +15,12 @@
 */
 
 import UIKit
-import Crashlytics
 import SVProgressHUD
-import Localytics
-import TwitterKit
 
+import UserNotifications
+import Localytics
+import Crashlytics
+import TwitterKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,45 +29,44 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var menuViewController: SDSlideMenuViewController!
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        let externalKeys = AppDelegate.loadExternalKeys()
-        
-        if isIOS8OrLater() {
-            UIApplication.shared.registerForRemoteNotifications()
-            let settings = UIUserNotificationSettings(types: [.alert, .sound, .badge], categories: nil)
-            UIApplication.shared.registerUserNotificationSettings(settings)
-        } else {
-            let types: UIRemoteNotificationType = [UIRemoteNotificationType.badge, UIRemoteNotificationType.sound, UIRemoteNotificationType.alert]
-            UIApplication.shared.registerForRemoteNotifications(matching: types)
-        }
-        
-        if let localyticsKey = externalKeys.localyticsKey {
-            Localytics.integrate(localyticsKey)
-            Localytics.setLoggingEnabled(true)
-            if application.applicationState != UIApplicationState.background {
-                Localytics.openSession()
-            }
-        }
-        
-        if let googleAnalyticsKey = externalKeys.googleAnalyticsKey {
-            GAI.sharedInstance().tracker(withTrackingId: googleAnalyticsKey)
-        }
-        if let crashlyticsKey = externalKeys.crashlyticsKey {
-            Crashlytics.start(withAPIKey: crashlyticsKey)
-        }
-        
-        if let twitterConsumerKey = externalKeys.twitterConsumerKey,
-            let twitterConsumerSecret = externalKeys.twitterConsumerSecret {
-            TWTRTwitter.sharedInstance().start(withConsumerKey: twitterConsumerKey, consumerSecret: twitterConsumerSecret)
-        }
-
+        setupThirdParties(application: application, options: launchOptions)
         initAppearence()
         createMenuView()
+
         return true
     }
 
+    // MARK: setup
+    private func createMenuView() {
+        let scheduleViewController = SDScheduleViewController(nibName: "SDScheduleViewController", bundle: nil)
+        menuViewController = SDSlideMenuViewController(nibName: "SDSlideMenuViewController", bundle: nil)
+        let nvc: UINavigationController = UINavigationController(rootViewController: scheduleViewController)
+
+        menuViewController.scheduleViewController = nvc
+        let slideMenuController = SlideMenuController(mainViewController: nvc, leftMenuViewController: menuViewController)
+
+        window = UIWindow(frame: UIScreen.main.bounds)
+        if let window = window {
+            window.backgroundColor = UIColor.appColor()
+            window.rootViewController = slideMenuController
+            window.makeKeyAndVisible()
+        }
+    }
+
+    private func initAppearence() {
+        UINavigationBar.appearance().barTintColor = UIColor.appColor()
+        UINavigationBar.appearance().tintColor = UIColor.white
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
+        UINavigationBar.appearance().backIndicatorImage = UIImage(named: "navigation_bar_icon_arrow")
+        UINavigationBar.appearance().backIndicatorTransitionMaskImage = UIImage(named: "navigation_bar_icon_arrow")
+        SVProgressHUD.setBackgroundColor(UIColor.clear)
+    }
+
+    // MARK: life cycle
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+        Localytics.dismissCurrentInAppMessage()
         Localytics.closeSession()
         Localytics.upload()
     }
@@ -90,50 +90,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Localytics.upload()
     }
 
-    private func createMenuView() {
-
-        let scheduleViewController = SDScheduleViewController(nibName: "SDScheduleViewController", bundle: nil)
-        menuViewController = SDSlideMenuViewController(nibName: "SDSlideMenuViewController", bundle: nil)
-        let nvc: UINavigationController = UINavigationController(rootViewController: scheduleViewController)
-
-        menuViewController.scheduleViewController = nvc
-        let slideMenuController = SlideMenuController(mainViewController: nvc, leftMenuViewController: menuViewController)
-
-        window = UIWindow(frame: UIScreen.main.bounds)
-        if let window = window {
-            window.backgroundColor = UIColor.appColor()
-            window.rootViewController = slideMenuController
-            window.makeKeyAndVisible()
-        }
-    }
-
-    private func initAppearence() {
-        UINavigationBar.appearance().barTintColor = UIColor.appColor()
-        UINavigationBar.appearance().tintColor = UIColor.white
-        UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
-        UINavigationBar.appearance().backIndicatorImage = UIImage(named: "navigation_bar_icon_arrow")
-        UINavigationBar.appearance().backIndicatorTransitionMaskImage = UIImage(named: "navigation_bar_icon_arrow")
-        UIApplication.shared.setStatusBarStyle(.lightContent, animated: false)
-        SVProgressHUD.setBackgroundColor(UIColor.clear)
-    }
-
-    class func loadExternalKeys() -> (googleAnalyticsKey: String?, crashlyticsKey: String?, localyticsKey: String?, twitterConsumerKey: String?, twitterConsumerSecret: String?) {
-        if let path = Bundle.main.path(forResource: kExternalKeysPlistFilename, ofType: "plist") {
-            if let keysDict = NSDictionary(contentsOfFile: path) {
-                return (keysDict[kExternalKeysDKGoogleAnalytics] as? String,
-                        keysDict[kExternalKeysDKCrashlytics] as? String,
-                        keysDict[kExternalKeysDKLocalytics] as? String,
-                        keysDict[kExternalKeysDKTwitterConsumerKey] as? String,
-                        keysDict[kExternalKeysDKTwitterConsumerSecret] as? String)
-            }
-        }
-        return (nil, nil, nil, nil, nil)
-    }
-
+    // MARK: deep link
     func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey:Any] = [:]) -> Bool {
         return TWTRTwitter.sharedInstance().application(application, open: url, options: options)
     }
+}
 
+// MARK: Localytics - Push Notifications
+extension AppDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Localytics.setPushToken(deviceToken)
     }
@@ -141,22 +105,116 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("Registration for Remote Notifications failed with error: \(error)")
     }
-    
+
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        func handleReload() {
-            if let jsonReload: AnyObject = userInfo["jsonReload"] as AnyObject {
-                if let jsonReloadBool = jsonReload as? NSString {
-                    if(jsonReloadBool .isEqual(to: "true")) {
-                        DataManager.sharedInstance.lastConnectionAttemptDate = nil
-                        self.menuViewController.askControllersToReload()
-                    }
-                }
+        defer {
+            if #available(iOS 10.0, *) {
+                Localytics.handleNotificationReceived(userInfo)
+            } else {
+                Localytics.handleNotification(userInfo)
             }
-            Localytics.handleNotification(userInfo)
+            completionHandler(.noData)
         }
-        
-        handleReload()        
-        completionHandler(.noData)
+
+        guard let jsonReload = userInfo["jsonReload"] as? String,
+            jsonReload.lowercased() == "true" else { return }
+
+        DataManager.sharedInstance.lastConnectionAttemptDate = nil
+        self.menuViewController.askControllersToReload()
+    }
+
+    func application(_ application: UIApplication, didReceive notification: UILocalNotification) {
+        guard let userInfo = notification.userInfo else { return }
+        Localytics.handleNotification(userInfo)
+    }
+
+    func application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
+        Localytics.didRegisterUserNotificationSettings()
     }
 }
 
+// MARK: Third parties
+extension AppDelegate {
+    private static var externalKeys = AppDelegate.loadExternalKeys()
+
+    private func setupThirdParties(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
+        localyticsPushNotifications(application: application, options: options)
+        localytics(application: application, options: options)
+        googleAnalytics(application: application)
+        crashlytics(application: application)
+        twitter(application: application)
+    }
+
+    // MARK: third parties
+    private func localyticsPushNotifications(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
+        if #available(iOS 12.0, *), objc_getClass("UNUserNotificationCenter") != nil {
+            let options: UNAuthorizationOptions = [.provisional]
+            UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
+                Localytics.didRequestUserNotificationAuthorization(withOptions: options.rawValue, granted: granted)
+            }
+        }
+        else if #available(iOS 10.0, *), objc_getClass("UNUserNotificationCenter") != nil {
+            let options: UNAuthorizationOptions = [.alert, .badge, .sound]
+            UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
+                Localytics.didRequestUserNotificationAuthorization(withOptions: options.rawValue, granted: granted)
+            }
+        }
+        else {
+            let types: UIUserNotificationType = [.alert, .badge, .sound]
+            let settings = UIUserNotificationSettings(types: types, categories: nil)
+            application.registerUserNotificationSettings(settings)
+        }
+
+        if let notificationInfo = options?[UIApplicationLaunchOptionsKey.localNotification] as? [AnyHashable: Any] {
+            Localytics.handleNotification(notificationInfo)
+        }
+    }
+
+    private func localytics(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
+        guard let localyticsKey = AppDelegate.externalKeys.localyticsKey else { return }
+
+        Localytics.autoIntegrate(localyticsKey, withLocalyticsOptions:[
+            LOCALYTICS_WIFI_UPLOAD_INTERVAL_SECONDS: 5,
+            LOCALYTICS_GREAT_NETWORK_UPLOAD_INTERVAL_SECONDS: 10,
+            LOCALYTICS_DECENT_NETWORK_UPLOAD_INTERVAL_SECONDS: 30,
+            LOCALYTICS_BAD_NETWORK_UPLOAD_INTERVAL_SECONDS: 90
+            ], launchOptions: options)
+
+        Localytics.setLoggingEnabled(true)
+
+        if application.applicationState != .background {
+            Localytics.openSession()
+        }
+    }
+
+    private func googleAnalytics(application: UIApplication) {
+        guard let googleAnalyticsKey = AppDelegate.externalKeys.googleAnalyticsKey else { return }
+        GAI.sharedInstance().tracker(withTrackingId: googleAnalyticsKey)
+    }
+
+    private func crashlytics(application: UIApplication) {
+        guard let crashlyticsKey = AppDelegate.externalKeys.crashlyticsKey else { return }
+        Crashlytics.start(withAPIKey: crashlyticsKey)
+    }
+
+    private func twitter(application: UIApplication) {
+        guard let twitterConsumerKey = AppDelegate.externalKeys.twitterConsumerKey,
+              let twitterConsumerSecret = AppDelegate.externalKeys.twitterConsumerSecret else { return }
+
+        TWTRTwitter.sharedInstance().start(withConsumerKey: twitterConsumerKey, consumerSecret: twitterConsumerSecret)
+    }
+}
+
+// MARK: helpers
+extension AppDelegate {
+    class func loadExternalKeys() -> (googleAnalyticsKey: String?, crashlyticsKey: String?, localyticsKey: String?, twitterConsumerKey: String?, twitterConsumerSecret: String?) {
+        guard let path = Bundle.main.path(forResource: kExternalKeysPlistFilename, ofType: "plist"),
+              let keysDict = NSDictionary(contentsOfFile: path) else { return (nil, nil, nil, nil, nil) }
+
+        return (keysDict[kExternalKeysDKGoogleAnalytics] as? String,
+                keysDict[kExternalKeysDKCrashlytics] as? String,
+                keysDict[kExternalKeysDKLocalytics] as? String,
+                keysDict[kExternalKeysDKTwitterConsumerKey] as? String,
+                keysDict[kExternalKeysDKTwitterConsumerSecret] as? String)
+    }
+}

--- a/ScalaDays/ScalaDays/AppDelegate.swift
+++ b/ScalaDays/ScalaDays/AppDelegate.swift
@@ -145,7 +145,6 @@ extension AppDelegate {
         twitter(application: application)
     }
 
-    // MARK: third parties
     private func localyticsPushNotifications(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
         if #available(iOS 12.0, *), objc_getClass("UNUserNotificationCenter") != nil {
             let options: UNAuthorizationOptions = [.provisional]

--- a/ScalaDays/ScalaDays/AppDelegate.swift
+++ b/ScalaDays/ScalaDays/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var menuViewController: SDSlideMenuViewController!
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        setupThirdParties(application: application, options: launchOptions)
+        setupThirdParties(application: application, launchOptions: launchOptions)
         initAppearence()
         createMenuView()
 
@@ -137,16 +137,16 @@ extension AppDelegate {
 extension AppDelegate {
     private static var externalKeys = AppDelegate.loadExternalKeys()
 
-    private func setupThirdParties(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
-        localyticsPushNotifications(application: application, options: options)
-        localytics(application: application, options: options)
+    private func setupThirdParties(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
+        localyticsPushNotifications(application: application, launchOptions: launchOptions)
+        localytics(application: application, launchOptions: launchOptions)
         googleAnalytics(application: application)
         crashlytics(application: application)
         twitter(application: application)
     }
 
     // MARK: third parties
-    private func localyticsPushNotifications(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
+    private func localyticsPushNotifications(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
         if #available(iOS 12.0, *), objc_getClass("UNUserNotificationCenter") != nil {
             let options: UNAuthorizationOptions = [.provisional]
             UNUserNotificationCenter.current().requestAuthorization(options: options) { (granted, error) in
@@ -165,12 +165,12 @@ extension AppDelegate {
             application.registerUserNotificationSettings(settings)
         }
 
-        if let notificationInfo = options?[UIApplicationLaunchOptionsKey.localNotification] as? [AnyHashable: Any] {
+        if let notificationInfo = launchOptions?[UIApplicationLaunchOptionsKey.localNotification] as? [AnyHashable: Any] {
             Localytics.handleNotification(notificationInfo)
         }
     }
 
-    private func localytics(application: UIApplication, options: [UIApplicationLaunchOptionsKey: Any]?) {
+    private func localytics(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
         guard let localyticsKey = AppDelegate.externalKeys.localyticsKey else { return }
 
         Localytics.autoIntegrate(localyticsKey, withLocalyticsOptions:[
@@ -178,7 +178,7 @@ extension AppDelegate {
             LOCALYTICS_GREAT_NETWORK_UPLOAD_INTERVAL_SECONDS: 10,
             LOCALYTICS_DECENT_NETWORK_UPLOAD_INTERVAL_SECONDS: 30,
             LOCALYTICS_BAD_NETWORK_UPLOAD_INTERVAL_SECONDS: 90
-            ], launchOptions: options)
+            ], launchOptions: launchOptions)
 
         Localytics.setLoggingEnabled(true)
 

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>5</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -69,9 +69,9 @@
 	<key>NSContactsUsageDescription</key>
 	<string>for saving new scanned contacts.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Location</string>
+	<string>This app may use GPS to track your location for the use of Google Maps and directions to and from pertinent locations for the event.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Location</string>
+	<string>This app may use GPS to track your location for the use of Google Maps and directions to and from pertinent locations for the event.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs access to your Photo Library.</string>
 	<key>UIBackgroundModes</key>

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>LSApplicationCategoryType</key>
-	<string></string>
+	<string>public.app-category.utilities</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>twitter</string>

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ScalaDays/ScalaDays/Info.plist
+++ b/ScalaDays/ScalaDays/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -26,9 +26,17 @@
 				<string>twitterkit-CYjDf81OaNIcZxlHpm1EB8xbD</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ampf03c22cb2db72bc6c180ece-0741609a-b833-11e4-2cc5-004a77f8b47f</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -60,6 +68,10 @@
 	<string>for scanning QR codes.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>for saving new scanned contacts.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Location</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs access to your Photo Library.</string>
 	<key>UIBackgroundModes</key>
@@ -70,6 +82,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Updated `localytics` to version 5.5. Update how it is working to keep the compatibility from iOS 9 to iOS 12 (using noninterrupting notifications provisionally to the Notification Center)

**NOTE** do not merge, we have to test it and update the privacy texts about GPS - it is necessary from April 2019