### PR TITLE
Preselect conference dates

### DIFF
--- a/ScalaDays/Helpers/Dates/SDDateHandler.swift
+++ b/ScalaDays/Helpers/Dates/SDDateHandler.swift
@@ -16,16 +16,24 @@
 
 import UIKit
 
+
 class SDDateHandler: NSObject {
-    lazy var dateFormatter: DateFormatter = DateFormatter()
-    let kResponseDateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-    let kScheduleDateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-    let kConferenceDateFormat = "yyyy-MM-dd"
-    let kScheduleOutputWeekDay = "EEEE"
-    let kScheduleOutputMonthDay = "dd"
-    let kScheduleOutputMonthName = "MMM"
-    let kScheduleOutputHours = "HH"
-    let kScheduleOutputMinutes = "mm"
+    
+    private lazy var dateFormatter: DateFormatter = DateFormatter()
+    
+    private enum Formatter: String {
+        case response = "EEE, dd MMM yyyy HH:mm:ss Z"
+        case schedule = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        case conference = "yyyy-MM-dd"
+        
+        enum Component: String {
+            case weekDay = "EEEE"
+            case monthDay = "dd"
+            case monthName = "MMM"
+            case hours = "HH"
+            case minutes = "mm"
+        }
+    }
     
     class var sharedInstance: SDDateHandler {
 
@@ -37,38 +45,36 @@ class SDDateHandler: NSObject {
     }
 
     func parseServerDate(_ dateString: String) -> Date? {
-        dateFormatter.dateFormat = kResponseDateFormat
+        dateFormatter.dateFormat = Formatter.response.rawValue
         dateFormatter.timeZone = TimeZone(abbreviation: "GMT")
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         return dateFormatter.date(from: dateString)
     }
 
     func parseScheduleDate(_ dateString: String) -> Date? {
-        dateFormatter.dateFormat = kScheduleDateFormat
+        dateFormatter.dateFormat = Formatter.schedule.rawValue
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         return dateFormatter.date(from: dateString)
     }
     
     func parseConferenceDate(_ dateString: String) -> Date? {
-        dateFormatter.dateFormat = kConferenceDateFormat
+        dateFormatter.dateFormat = Formatter.conference.rawValue
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         return dateFormatter.date(from: dateString)
     }
     
     func formatScheduleDetailDate(_ date: Date) -> String? {
-        
-        
-        dateFormatter.dateFormat = kScheduleOutputWeekDay
+        dateFormatter.dateFormat = Formatter.Component.weekDay.rawValue
         let weekDay = dateFormatter.string(from: date)
-        dateFormatter.dateFormat = kScheduleOutputMonthDay
+        dateFormatter.dateFormat = Formatter.Component.monthDay.rawValue
         let monthDayNumber = dateFormatter.string(from: date)
-        dateFormatter.dateFormat = kScheduleOutputMonthName
+        dateFormatter.dateFormat = Formatter.Component.monthName.rawValue
         let monthName = dateFormatter.string(from: date)
-        dateFormatter.dateFormat = kScheduleOutputHours
+        dateFormatter.dateFormat = Formatter.Component.hours.rawValue
         let hours = dateFormatter.string(from: date)
-        dateFormatter.dateFormat = kScheduleOutputMinutes
+        dateFormatter.dateFormat = Formatter.Component.minutes.rawValue
         let minutes = dateFormatter.string(from: date)
         
         if let monNumber = Int(monthDayNumber){

--- a/ScalaDays/Models/Conference.swift
+++ b/ScalaDays/Models/Conference.swift
@@ -102,6 +102,25 @@ class Information: NSObject, Codable {
         self.pictures = pictures
         self.testMode = testMode
     }
+    
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        id = try values.decode(Int.self, forKey: .id)
+        name = try values.decode(String.self, forKey: .name)
+        longName = try values.decode(String.self, forKey: .longName)
+        nameAndLocation = try values.decode(String.self, forKey: .nameAndLocation)
+        firstDay = try values.decode(String.self, forKey: .firstDay)
+        lastDay = try values.decode(String.self, forKey: .lastDay)
+        normalSite = try values.decode(String.self, forKey: .normalSite)
+        registrationSite = try values.decode(String.self, forKey: .registrationSite)
+        utcTimezoneOffset = (try values.decode(String.self, forKey: .utcTimezoneOffset)).replacingOccurrences(of: " ", with: "_")
+        utcTimezoneOffsetMillis = try values.decode(Float.self, forKey: .utcTimezoneOffsetMillis)
+        hashtag = try values.decode(String.self, forKey: .hashtag)
+        query = try values.decode(String?.self, forKey: .query)
+        pictures = try values.decode([Picture].self, forKey: .pictures)
+        testMode = try values.decode(Bool.self, forKey: .testMode)
+    }
 }
 
 class Picture: NSObject, Codable {

--- a/ScalaDays/Models/Conference.swift
+++ b/ScalaDays/Models/Conference.swift
@@ -42,6 +42,14 @@ class Conference: NSObject, Codable {
         SDDateHandler.sharedInstance.localEndDate(conference: self)
     }
     
+    var localStartDateFirstEvent: Date? {
+        SDDateHandler.sharedInstance.localStartDateFirstEvent(conference: self)
+    }
+    
+    var localEndDateLastEvent: Date? {
+        SDDateHandler.sharedInstance.localEndDateLastEvent(conference: self)
+    }
+    
     var isActive: Bool {
         SDDateHandler.sharedInstance.isConferenceActive(self)
     }


### PR DESCRIPTION
We are using for preselection conference the date in the events and it should be done using the `Date` inside conference information.

Also, I have fixed a bug in UTC Timezone Offset: backend is sending us blank spaces in timezone description.